### PR TITLE
bugfix: short *one* stylesheet due to off by 1 error, when juice'n

### DIFF
--- a/lib/juice.js
+++ b/lib/juice.js
@@ -273,11 +273,12 @@ function getRemoteContent(remoteUrl, callback) {
 function getStylesheetList(document, options) {
   var results = [];
   var linkList = document.getElementsByTagName("link");
-  var link, i, j, attr, attrs;
-  for (i = 0; i < linkList.length; ++i) {
+  var link, i, j, attr, attrs, length1, length2;
+  
+  for (i = 0, length1 = linkList.length; i < length1; i++) {
     link = linkList[i];
     attrs = {};
-    for (j = 0; j < link.attributes.length; ++j) {
+    for (j = 0, length2 = link.attributes.length; j < length2; j++) {
       attr = link.attributes[j];
       attrs[attr.name.toLowerCase()] = attr.value;
     }


### PR DESCRIPTION
- preformance: cache's length of array in variable
- uses i++ instead of ++i, helped me when I was hunting the bug.
