### PR TITLE
Fixes for Windows paths

### DIFF
--- a/lib/juice.js
+++ b/lib/juice.js
@@ -140,6 +140,7 @@ function juiceDocument(document, options, callback) {
   assert.ok(options.url, "options.url is required");
   options = getDefaultOptions(options);
   extractCssFromDocument(document, options, function(err, css) {
+    if (err) throw err;
     css += "\n" + options.extraCss;
     inlineDocumentWithCb(document, css, callback);
   });

--- a/lib/juice.js
+++ b/lib/juice.js
@@ -188,8 +188,7 @@ function juiceFile(filePath, options, callback) {
   fs.readFile(filePath, 'utf8', function(err, content) {
     if (err) return callback(err);
     options = getDefaultOptions(options); // so we can mutate options without guilt
-    var slashes = os.platform() === 'win32' ? '\\\\' : '//';
-    options.url = options.url || ("file:" + slashes + path.resolve(process.cwd(), filePath));
+    options.url = options.url || path.resolve(process.cwd(), filePath);
     juiceContent(content, options, callback);
   });
 }
@@ -250,12 +249,14 @@ function getStylesData(document, options, callback) {
 }
 
 function getHrefContent(destHref, sourceHref, callback) {
-  var resolvedUrl = url.resolve(sourceHref, destHref);
-  var parsedUrl = url.parse(resolvedUrl);
-  if (parsedUrl.protocol === 'file:') {
-    fs.readFile(decodeURIComponent(parsedUrl.pathname), 'utf8', callback);
-  } else {
+  var isRemote = /^(:?https?:)?\/\//.test(destHref);
+
+  if (isRemote) {
     getRemoteContent(resolvedUrl, callback);
+  }
+  else {
+    var resolvedUrl = url.resolve(sourceHref.replace(/\\/g, "/"), destHref); //url.resolve works best with forward slashes
+    fs.readFile(resolvedUrl, 'utf8', callback);
   }
 }
 


### PR DESCRIPTION
Nothing was working for me on Windows but was for others on Unix-like systems. I debugged it and found out that it couldn't open my file because of path resolving issues, and that was failing silently. So I made it throw an error instead of failing silently, and did some simplifying and replaced backslashes with forward slashes before resolving the full path.
