### PR TITLE
Preserve single quotes for values

### DIFF
--- a/lib/juice.js
+++ b/lib/juice.js
@@ -110,7 +110,7 @@ function inlineDocument(document, css) {
             , value = style[name]
             , sel = style._importants[name] ? importantSelector : selector
             , prop = new Property(name, value, sel)
-            , existing = el.styleProps[name]
+            , existing = el.styleProps[name];
 
           if (existing) {
             var winner = existing.compare(prop)
@@ -130,9 +130,9 @@ function inlineDocument(document, css) {
   function setStyleAttrs(el) {
     var style = [];
     for (var i in el.styleProps) {
-    	style.push( el.styleProps[i].toString() );
+      style.push(el.styleProps[i].prop + ": " + el.styleProps[i].value.replace(/["]/g, "'") + ";");
     }
-	// sorting will arrange styles like padding: before padding-bottom: which will preserve the expected styling
+    // sorting will arrange styles like padding: before padding-bottom: which will preserve the expected styling
     style = style.sort( function ( a, b )
     {
     	var aProp = a.split( ':' )[0];

--- a/test/cases/css-quotes.out
+++ b/test/cases/css-quotes.out
@@ -1,3 +1,3 @@
 <html><body>
-<p style="background: url(/woot);">woot</p>
+<p style="background: url('/woot');">woot</p>
 </body></html>

--- a/test/cases/juice-content/font-quotes.html
+++ b/test/cases/juice-content/font-quotes.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+    <style>
+        p {
+            font-family: 'Open Sans', Arial, sans-serif;
+        }
+    </style>
+</head>
+<body>
+    <p style="">hi</p>
+    <p style=''>there</p>
+</body>
+</html>

--- a/test/cases/juice-content/font-quotes.json
+++ b/test/cases/juice-content/font-quotes.json
@@ -1,0 +1,4 @@
+{
+    "url": "./",
+    "removeStyleTags": true
+}

--- a/test/cases/juice-content/font-quotes.out
+++ b/test/cases/juice-content/font-quotes.out
@@ -1,0 +1,9 @@
+<html>
+<head>
+    
+</head>
+<body>
+    <p style="font-family: 'Open Sans', Arial, sans-serif;">hi</p>
+    <p style="font-family: 'Open Sans', Arial, sans-serif;">there</p>
+</body>
+</html>


### PR DESCRIPTION
The previous toString() call being used to generate the styles stripped
out all single and double quotes. There is a technical difference
between some quoted and non-quoted values, as discussed here
http://stackoverflow.com/questions/7638775/do-i-need-to-wrap-quotes-around-font-family-names-in-css

To fix this, the use of toString() is replaced with a very similar bit
of code that replace double quotes with single quotes. Because all
Juice'd output styles use double quotes, this is reliable.

A test case was added and one test case that had a minor failure from
the update, was updated. This should be a non-breaking change.
