### PR TITLE
Add option applyWidthAttributes to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Output:
      within `<style></style>` tags as a refinement when `removeStyleTags` is `true`. 
      Other styles are removed. Defaults to `false`.
    - `applyWidthAttributes` - whether to use any CSS pixel widths to create
-     `width` attributes on elements that support widths: `table`, `td`, `img`, `input`
+     `width` attributes on elements set in `juice.widthElements`
    - `removeLinkTags` - whether to remove the original `<link rel="stylesheet">`
      tags after (possibly) inlining the css from them. Defaults to `true`.
    - `url` - how to resolve hrefs. Defaults to using `filePath`. If you want

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Output:
    - `preserveMediaQueries` - preserves all media queries (and contained styles) 
      within `<style></style>` tags as a refinement when `removeStyleTags` is `true`. 
      Other styles are removed. Defaults to `false`.
+   - `applyWidthAttributes` - whether to use any CSS pixel widths to create
+     `width` attributes on elements that support widths: `table`, `td`, `img`, `input`
    - `removeLinkTags` - whether to remove the original `<link rel="stylesheet">`
      tags after (possibly) inlining the css from them. Defaults to `true`.
    - `url` - how to resolve hrefs. Defaults to using `filePath`. If you want
@@ -113,7 +115,7 @@ call `document.parentWindow.close()` to free up memory.
 This takes html and css and returns new html with the provided css inlined.
 It does not look at `<style>` or `<link rel="stylesheet">` elements at all.
 
-### juice.inlineDocument(document, css)
+### juice.inlineDocument(document, css, options)
 
 Given a jsdom instance and css, this modifies the jsdom instance so that the
 provided css is inlined. It does not look at `<style>` or
@@ -122,6 +124,10 @@ provided css is inlined. It does not look at `<style>` or
 ### juice.ignoredPseudos
 
 Array of ignored pseudo-selectors such as 'hover' and 'active'.
+
+### juice.widthElements
+
+Array of HTML elements that can receive `width` attributes.
 
 ## Credits
 

--- a/lib/juice.js
+++ b/lib/juice.js
@@ -51,7 +51,7 @@ juice.utils = require('./utils');
 
 
 juice.ignoredPseudos = ['hover', 'active', 'focus', 'visited', 'link'];
-juice.widthElements = ['TABLE', 'TD', 'IMG', 'INPUT'];
+juice.widthElements = ['TABLE', 'TD', 'IMG'];
 
 juice.juiceDocument = juiceDocument;
 juice.juiceContent = juiceContent;

--- a/lib/juice.js
+++ b/lib/juice.js
@@ -222,7 +222,7 @@ function juiceFile(filePath, options, callback) {
 
 function inlineContent(html, css) {
   var document = utils.jsdom(html);
-  inlineDocument(document, css);
+  inlineDocument(document, css, {});
   var inner = utils.docToString(document);
   // free the associated memory
   // with lazily created parentWindow

--- a/lib/juice.js
+++ b/lib/juice.js
@@ -51,6 +51,7 @@ juice.utils = require('./utils');
 
 
 juice.ignoredPseudos = ['hover', 'active', 'focus', 'visited', 'link'];
+juice.widthElements = ['TABLE', 'TD', 'IMG', 'INPUT'];
 
 juice.juiceDocument = juiceDocument;
 juice.juiceContent = juiceContent;
@@ -58,17 +59,22 @@ juice.juiceFile = juiceFile;
 juice.inlineDocument = inlineDocument;
 juice.inlineContent = inlineContent;
 
-function inlineDocument(document, css) {
+function inlineDocument(document, css, options) {
+
   var rules = utils.parseCSS(css)
-    , editedElements = []
+    , editedElements = [];
 
   rules.forEach(handleRule);
   editedElements.forEach(setStyleAttrs);
 
+  if (options && options.applyWidthAttributes) {
+    editedElements.forEach(setWidthAttrs);
+  }
+
   function handleRule(rule) {
     var sel = rule[0]
       , style = rule[1]
-      , selector = new Selector(sel)
+      , selector = new Selector(sel);
 
     // skip rule if the selector has any pseudos which are ignored
     var parsedSelector = selector.parsed();
@@ -141,6 +147,18 @@ function inlineDocument(document, css) {
     } );
     el.setAttribute('style', style.join(' '));
   }
+  
+  function setWidthAttrs(el) {
+    if (juice.widthElements.indexOf(el.nodeName) > -1) {
+      for (var i in el.styleProps) {
+        if (el.styleProps[i].prop === 'width' && el.styleProps[i].value.match(/px/)) {
+          var pxWidth = el.styleProps[i].value.replace('px', '');
+          el.setAttribute('width', pxWidth);
+          return;
+        }
+      }
+    }
+  }
 }
 
 function juiceDocument(document, options, callback) {
@@ -148,7 +166,7 @@ function juiceDocument(document, options, callback) {
   options = getDefaultOptions(options);
   extractCssFromDocument(document, options, function(err, css) {
     css += "\n" + options.extraCss;
-    inlineDocumentWithCb(document, css, callback);
+    inlineDocumentWithCb(document, css, options, callback);
   });
 }
 
@@ -187,6 +205,7 @@ function getDefaultOptions(options) {
     applyLinkTags: true,
     removeLinkTags: true,
     preserveMediaQueries: false,
+    applyWidthAttributes: false,
   }, options);
 }
 
@@ -229,9 +248,9 @@ function juice (arg1, arg2, arg3) {
   juiceFile(arg1, options, callback);
 }
 
-function inlineDocumentWithCb(document, css, callback) {
+function inlineDocumentWithCb(document, css, options, callback) {
   try {
-    inlineDocument(document, css);
+    inlineDocument(document, css, options);
     callback();
   } catch (err) {
     callback(err);

--- a/test/cases/juice-content/width-attr.html
+++ b/test/cases/juice-content/width-attr.html
@@ -1,0 +1,20 @@
+<html>
+<head>
+    <style>
+        p, td, img {
+            width: 200px;
+        }
+    </style>
+</head>
+<body>
+    <p>none</p>
+    <table>
+        <tr>
+            <td>
+                wide
+            </td>
+        </tr>
+    </table>
+    <img src="" alt="wide">
+</body>
+</html>

--- a/test/cases/juice-content/width-attr.json
+++ b/test/cases/juice-content/width-attr.json
@@ -1,0 +1,5 @@
+{
+    "url": "./",
+    "removeStyleTags": true,
+    "applyWidthAttributes": true
+}

--- a/test/cases/juice-content/width-attr.out
+++ b/test/cases/juice-content/width-attr.out
@@ -1,0 +1,16 @@
+<html>
+<head>
+    
+</head>
+<body>
+    <p style="width: 200px;">none</p>
+    <table>
+        <tr>
+            <td style="width: 200px;" width="200">
+                wide
+            </td>
+        </tr>
+    </table>
+    <img src="" alt="wide" style="width: 200px;" width="200">
+</body>
+</html>


### PR DESCRIPTION
This addresses the issue where some mail clients, like Outlook, require there to be a `width` attribute defined on images in order to set a width other than the natural width. The change is setup so that an option has been added `applyWidthAttributes` and when set to `true` (the default is `false` to maintain backward compatibility) the `width` attribute on elements of types in the new `juice.widthElements` array (default is [TABLE, TD, IMG]) are set to any pixel width CSS values applied to those elements. 

This change removes the need to set widths in CSS and again in HTML for some elements, so code is DRYer and behaves closer to browser CSS.

I don't believe this change to be breaking, a new test has been added and all preexisting tests pass without changes.
