### PR TITLE
Should return error if link path can not be found

### DIFF
--- a/lib/juice.js
+++ b/lib/juice.js
@@ -165,6 +165,7 @@ function juiceDocument(document, options, callback) {
   assert.ok(options.url, "options.url is required");
   options = getDefaultOptions(options);
   extractCssFromDocument(document, options, function(err, css) {
+    if(err) return callback(err);
     css += "\n" + options.extraCss;
     inlineDocumentWithCb(document, css, options, callback);
   });


### PR DESCRIPTION
CSS does not get inlined when a user provides an unknown path to the `link` tag. I think the error should be returned. It seems to fail silently right now and returns the original html. 
