### PR TITLE
Bump dependencies (most importantly, jsdom) and version number, update jsdom methods

### DIFF
--- a/lib/juice.js
+++ b/lib/juice.js
@@ -147,7 +147,7 @@ function inlineDocument(document, css, options) {
     } );
     el.setAttribute('style', style.join(' '));
   }
-  
+
   function setWidthAttrs(el) {
     if (juice.widthElements.indexOf(el.nodeName) > -1) {
       for (var i in el.styleProps) {
@@ -186,7 +186,7 @@ function juiceContent(html, options, callback) {
       } catch (cleanupErr) {}
       callback(err);
     } else {
-      var inner = document.innerHTML;
+      var inner = document.documentElement.innerHTML;
       // free the associated memory
       // with lazily created parentWindow
       try {
@@ -224,7 +224,7 @@ function juiceFile(filePath, options, callback) {
 function inlineContent(html, css) {
   var document = utils.jsdom(html);
   inlineDocument(document, css, {});
-  var inner = document.innerHTML;
+  var inner = document.documentElement.innerHTML;
   // free the associated memory
   // with lazily created parentWindow
   try {
@@ -328,7 +328,7 @@ function getStylesheetList(document, options) {
   var results = [];
   var linkList = document.getElementsByTagName("link");
   var link, i, j, attr, attrs, length1, length2;
-  
+
   for (i = 0, length1 = linkList.length; i < length1; i++) {
     link = linkList[i];
     attrs = {};
@@ -352,7 +352,7 @@ function extractCssFromDocument(document, options, callback) {
   var stylesData;
   var moreStylesData = [];
 
-  pend.go(function(callback) { 
+  pend.go(function(callback) {
     getStylesData(document, options, function(err, val) {
       stylesData = val;
       callback(err);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,7 @@
 
 var fs = require('fs')
   , cssom = require('cssom')
-  , jsdom = require('jsdom')
+  , jsdom = require('jsdom').jsdom
   , own = {}.hasOwnProperty
   , os = require('os');
 
@@ -81,52 +81,52 @@ exports.parseCSS = function (css) {
 
 exports.getMediaQueryText = function ( css )
 {
-	var rules = cssom.parse( css ).cssRules || []
-	var queries = [];
+  var rules = cssom.parse( css ).cssRules || []
+  var queries = [];
 
-	for ( var i = 0, l = rules.length; i < l; i++ )
-	{
-		/* CSS types
-		  STYLE: 1,
-		  IMPORT: 3,
-		  MEDIA: 4,
-		  FONT_FACE: 5,
-		 */
+  for ( var i = 0, l = rules.length; i < l; i++ )
+  {
+    /* CSS types
+      STYLE: 1,
+      IMPORT: 3,
+      MEDIA: 4,
+      FONT_FACE: 5,
+     */
 
-		if ( rules[i].type === cssom.CSSMediaRule.prototype.type )
-		{
-			var query = rules[i];
-			var queryString = [];
+    if ( rules[i].type === cssom.CSSMediaRule.prototype.type )
+    {
+      var query = rules[i];
+      var queryString = [];
 
-			queryString.push( os.EOL + "@media " + query.media[0] + " {" );
+      queryString.push( os.EOL + "@media " + query.media[0] + " {" );
 
-			for ( var ii = 0, ll = query.cssRules.length; ii < ll; ii++ )
-			{
-				var rule = query.cssRules[ii];
+      for ( var ii = 0, ll = query.cssRules.length; ii < ll; ii++ )
+      {
+        var rule = query.cssRules[ii];
 
-				if ( rule.type === cssom.CSSStyleRule.prototype.type || rule.type === cssom.CSSFontFaceRule.prototype.type )
-				{
-					queryString.push( "  " + ( rule.type === cssom.CSSStyleRule.prototype.type ? rule.selectorText : "@font-face" ) + " {" );
+        if ( rule.type === cssom.CSSStyleRule.prototype.type || rule.type === cssom.CSSFontFaceRule.prototype.type )
+        {
+          queryString.push( "  " + ( rule.type === cssom.CSSStyleRule.prototype.type ? rule.selectorText : "@font-face" ) + " {" );
 
-					for ( var style = 0; style < rule.style.length; style++ )
-					{
-						var property = rule.style[style];
-						var value = rule.style[property];
-						var important = rule.style._importants[property] ? " !important" : "";
-						queryString.push( "    " + property + ": " + value + important + ";" );
-					}
-					queryString.push( "  }" );
-				}
-			}
+          for ( var style = 0; style < rule.style.length; style++ )
+          {
+            var property = rule.style[style];
+            var value = rule.style[property];
+            var important = rule.style._importants[property] ? " !important" : "";
+            queryString.push( "    " + property + ": " + value + important + ";" );
+          }
+          queryString.push( "  }" );
+        }
+      }
 
-			queryString.push( "}" );
-			var result = queryString.length ? queryString.join( os.EOL ) + os.EOL : "";
+      queryString.push( "}" );
+      var result = queryString.length ? queryString.join( os.EOL ) + os.EOL : "";
 
-			queries.push( result );
-		}
-	}
+      queries.push( result );
+    }
+  }
 
-	return queries.join( os.EOL );
+  return queries.join( os.EOL );
 }
 
 /**
@@ -136,7 +136,7 @@ exports.getMediaQueryText = function ( css )
  */
 
 exports.jsdom = function (html) {
-  return jsdom.html(html, null, {
+  return jsdom(html, {
     features: {
         QuerySelector: ['1.0']
       , FetchExternalResources: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juice2",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Inlines css into html source",
   "bin": "./bin/juice",
   "scripts": {
@@ -10,12 +10,12 @@
     "node": ">=0.10.20"
   },
   "dependencies": {
-    "slick": "~1.12.1",
-    "commander": "~2.3.0",
-    "cssom": "~0.3.0",
-    "superagent": "~0.18.2",
-    "jsdom": "~0.11.1",
-    "pend": "~1.1.2"
+    "commander": "^2.8.1",
+    "cssom": "^0.3.0",
+    "jsdom": "^3.1.2",
+    "pend": "^1.2.0",
+    "slick": "^1.12.2",
+    "superagent": "^1.2.0"
   },
   "devDependencies": {
     "should": "~4.0.4",


### PR DESCRIPTION
I took a look at the changes made in @sunnylost 's fork, as discussed here: #16 (comment)

Made those changes manually, ran my task that used this module, and then I no longer received this error: #29

All this PR does is bump all the dependencies, the version number, and updates the jsdom methods in order to work with the newer version of jsdom, with thanks to @sunnylost for figuring out how to get it working again. **Note**: jsdom is currently at major version 5, but anything version 4 and above is only meant to work with iojs, so this PR only uses jsdom version 3.

Please merge so people using your module in favour of the original Juice can actually use this without issue. Thanks :smile:
